### PR TITLE
Fix fallback IP lookup for Proxmox LXC

### DIFF
--- a/Proxmox.sh
+++ b/Proxmox.sh
@@ -326,7 +326,7 @@ def get_guest_ips():
         except Exception:
             # Fallback: parse /config (DHCP lease) or skip
             conf = get_proxmox(f"nodes/{NODE}/lxc/{vmid}/config")
-            net0 = conf.get("net0", "")
+            net0 = conf.get("data", {}).get("net0", "")
             if "ip=" in net0:
                 ip = net0.split("ip=")[1].split("/")[0]
                 records[name] = ip


### PR DESCRIPTION
## Summary
- correctly read `net0` from the `data` section when guest agent is unavailable

## Testing
- `bash -n Proxmox.sh`
- `python3 -` (AST parse of embedded script)


------
https://chatgpt.com/codex/tasks/task_e_684379bfd05c8330baa9a9cf295f5ce3