### PR TITLE
Load configuration from hosted-dns.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # ProxMoxMonitorDash
+
+## Configuration
+
+`Proxmox.sh` reads its zone, cluster name and Tailscale API key from
+`/etc/hosted-dns.conf` if the file exists. You may also set the following
+environment variables before running the script:
+
+```bash
+export ZONE=my.domain
+export CLUSTER_NAME=mycluster
+export TS_API_KEY=tskey-XXXXX
+```
+
+If `/etc/hosted-dns.conf` does not exist it will be created using the values
+from these variables (or the script defaults) on first run.


### PR DESCRIPTION
## Summary
- source ZONE, CLUSTER_NAME and TS_API_KEY from `/etc/hosted-dns.conf` or environment variables in `Proxmox.sh`
- add a required check for `TS_API_KEY`
- document the configuration method in `README.md`

## Testing
- `bash -n Proxmox.sh`
- `python3 -m py_compile temp.py`

------
https://chatgpt.com/codex/tasks/task_e_6848a78e35608330912247bf605592c5