### PR TITLE
Extend get_guest_ips to include qemu guests

### DIFF
--- a/Proxmox.sh
+++ b/Proxmox.sh
@@ -330,6 +330,27 @@ def get_guest_ips():
             if "ip=" in net0:
                 ip = net0.split("ip=")[1].split("/")[0]
                 records[name] = ip
+
+    # QEMU guests: /nodes/<node>/qemu
+    qemu_list = get_proxmox(f"nodes/{NODE}/qemu")
+    for item in qemu_list.get("data", []):
+        vmid = item.get("vmid")
+        name = item.get("name")
+        if item.get("status") != "running":
+            continue
+        try:
+            iface = get_proxmox(f"nodes/{NODE}/qemu/{vmid}/agent/network-get-interfaces")
+            for entry in iface.get("result", []):
+                if "ip-addresses" in entry and entry["ip-addresses"]:
+                    ip = entry["ip-addresses"][0]["ip-address"]
+                    records[name] = ip
+                    break
+        except Exception:
+            conf = get_proxmox(f"nodes/{NODE}/qemu/{vmid}/config")
+            net0 = conf.get("data", {}).get("net0", "")
+            if "ip=" in net0:
+                ip = net0.split("ip=")[1].split("/")[0]
+                records[name] = ip
     return records
 
 def fetch_ag_rewrites():


### PR DESCRIPTION
## Summary
- update the embedded update-hosted-dns.py in `Proxmox.sh`
- query `/nodes/<node>/qemu` to pull running VM guest IPs

## Testing
- `bash -n Proxmox.sh`
- `python3 -m py_compile tmp_pycode.py`

------
https://chatgpt.com/codex/tasks/task_e_6848a79030f08330bdb6f3862d9e0596